### PR TITLE
feat: set up Anthropic SDK alongside OpenAI (#29)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,10 @@
 OPENAI_API_KEY=your_openai_api_key_here
 OPENAI_MODEL=gpt-4o-mini
 
+# Anthropic
+ANTHROPIC_API_KEY=your_anthropic_api_key_here
+ANTHROPIC_MODEL=claude-sonnet-4-20250514
+
 # Database (Supabase PostgreSQL — use the pooler connection string)
 DATABASE_URL=postgresql://postgres.YOUR_PROJECT_REF:YOUR_PASSWORD@aws-1-eu-west-1.pooler.supabase.com:6543/postgres
 

--- a/backend/core/llm.py
+++ b/backend/core/llm.py
@@ -1,0 +1,165 @@
+# ─────────────────────────────────────────────────────────
+# FILE: backend/core/llm.py
+# Dual-client LLM wrapper — abstracts OpenAI and Anthropic
+# behind a unified interface so the rest of the codebase
+# doesn't care which provider is being used.
+# ─────────────────────────────────────────────────────────
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+
+from openai import OpenAI
+from anthropic import Anthropic
+
+
+# ─── Response ────────────────────────────────────────────
+
+@dataclass
+class LLMResponse:
+    """Provider-agnostic response object."""
+    content: str
+    model: str
+    provider: str
+    usage: dict = field(default_factory=dict)
+
+
+# ─── OpenAI client ───────────────────────────────────────
+
+class OpenAIClient:
+    """Thin wrapper around the OpenAI SDK."""
+
+    provider = "openai"
+
+    def __init__(self, api_key: str | None = None, model: str | None = None):
+        self.api_key = api_key or os.getenv("OPENAI_API_KEY", "")
+        self.model = model or os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+        self._client = OpenAI(api_key=self.api_key)
+
+    def chat(
+        self,
+        messages: list[dict],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 4000,
+    ) -> LLMResponse:
+        response = self._client.chat.completions.create(
+            model=self.model,
+            messages=messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+        choice = response.choices[0]
+        return LLMResponse(
+            content=choice.message.content,
+            model=response.model,
+            provider=self.provider,
+            usage={
+                "prompt_tokens": response.usage.prompt_tokens,
+                "completion_tokens": response.usage.completion_tokens,
+            },
+        )
+
+    def ping(self) -> bool:
+        """Lightweight check that the API key is valid."""
+        try:
+            self._client.models.list()
+            return True
+        except Exception:
+            return False
+
+
+# ─── Anthropic client ────────────────────────────────────
+
+class AnthropicClient:
+    """Thin wrapper around the Anthropic SDK."""
+
+    provider = "anthropic"
+
+    def __init__(self, api_key: str | None = None, model: str | None = None):
+        self.api_key = api_key or os.getenv("ANTHROPIC_API_KEY", "")
+        self.model = model or os.getenv("ANTHROPIC_MODEL", "claude-sonnet-4-20250514")
+        self._client = Anthropic(api_key=self.api_key)
+
+    def chat(
+        self,
+        messages: list[dict],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 4000,
+    ) -> LLMResponse:
+        # Anthropic expects 'system' as a top-level param, not inside messages.
+        system_text = ""
+        chat_messages = []
+        for msg in messages:
+            if msg["role"] == "system":
+                system_text += msg["content"] + "\n"
+            else:
+                chat_messages.append({"role": msg["role"], "content": msg["content"]})
+
+        response = self._client.messages.create(
+            model=self.model,
+            system=system_text.strip(),
+            messages=chat_messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+        return LLMResponse(
+            content=response.content[0].text,
+            model=response.model,
+            provider=self.provider,
+            usage={
+                "input_tokens": response.usage.input_tokens,
+                "output_tokens": response.usage.output_tokens,
+            },
+        )
+
+    def ping(self) -> bool:
+        """Lightweight check that the API key is valid."""
+        try:
+            self._client.messages.create(
+                model=self.model,
+                max_tokens=10,
+                messages=[{"role": "user", "content": "ping"}],
+            )
+            return True
+        except Exception:
+            return False
+
+
+# ─── Provider registry ───────────────────────────────────
+
+_clients: dict[str, OpenAIClient | AnthropicClient] = {}
+
+
+def get_client(provider: str = "openai") -> OpenAIClient | AnthropicClient:
+    """Return a cached client instance for the given provider.
+
+    Usage:
+        from backend.core.llm import get_client
+        client = get_client("anthropic")
+        resp = client.chat(messages=[...])
+    """
+    if provider not in _clients:
+        if provider == "openai":
+            _clients[provider] = OpenAIClient()
+        elif provider == "anthropic":
+            _clients[provider] = AnthropicClient()
+        else:
+            raise ValueError(f"Unknown LLM provider: {provider!r}. Use 'openai' or 'anthropic'.")
+    return _clients[provider]
+
+
+def check_providers() -> dict[str, bool]:
+    """Check connectivity for all configured providers. Used by health endpoint."""
+    results = {}
+    if os.getenv("OPENAI_API_KEY"):
+        results["openai"] = get_client("openai").ping()
+    else:
+        results["openai"] = False
+    if os.getenv("ANTHROPIC_API_KEY"):
+        results["anthropic"] = get_client("anthropic").ping()
+    else:
+        results["anthropic"] = False
+    return results

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ starlette==0.46.2
 python-multipart
 pymupdf
 openai
+anthropic
 python-dotenv
 PyJWT[crypto]
 sqlalchemy

--- a/server.py
+++ b/server.py
@@ -14,7 +14,6 @@ from fastapi.staticfiles import StaticFiles
 from starlette.middleware.base import BaseHTTPMiddleware
 from pydantic import BaseModel
 from dotenv import load_dotenv
-from openai import OpenAI
 from sqlalchemy.orm import Session
 
 load_dotenv()
@@ -26,6 +25,7 @@ from backend.core.auth import require_auth
 from backend.models.user import User
 from backend.routes.auth import router as auth_router
 from backend.services.analysis import store_analysis
+from backend.core.llm import get_client, check_providers
 
 app = FastAPI()
 
@@ -58,9 +58,6 @@ app.add_middleware(CacheControlMiddleware)
 
 # Mount auth routes
 app.include_router(auth_router)
-
-client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
-MODEL = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
 
 # In-memory session store
 sessions = {}
@@ -121,8 +118,8 @@ def extract_highlights(text: str) -> list[dict] | None:
 def extract_scores_via_llm(analysis_text: str) -> dict | None:
     """Fallback: ask the LLM to extract scores from an analysis that's missing markers."""
     try:
-        response = client.chat.completions.create(
-            model=MODEL,
+        openai_client = get_client("openai")
+        resp = openai_client.chat(
             messages=[
                 {"role": "system", "content": (
                     "Extract numerical scores (0-100) from the resume analysis below. "
@@ -137,7 +134,7 @@ def extract_scores_via_llm(analysis_text: str) -> dict | None:
             temperature=0,
             max_tokens=200,
         )
-        return extract_scores(response.choices[0].message.content)
+        return extract_scores(resp.content)
     except Exception as e:
         print(f"[SCORES] LLM fallback failed: {e}")
         return None
@@ -249,14 +246,14 @@ def run_completion(session_data: dict, message: str) -> str:
 
     messages.append({"role": "user", "content": message})
 
+    # Route to the right provider — for now everything stays on OpenAI.
+    # Phase 1 just proves the plumbing works; later tickets will flip
+    # interview + career to Anthropic.
+    llm = get_client("openai")
+
     try:
-        response = client.chat.completions.create(
-            model=MODEL,
-            messages=messages,
-            temperature=0.7,
-            max_tokens=4000,
-        )
-        assistant_reply = response.choices[0].message.content
+        resp = llm.chat(messages=messages, temperature=0.7, max_tokens=4000)
+        assistant_reply = resp.content
 
         history.append({"role": "user", "content": message})
         history.append({"role": "assistant", "content": assistant_reply})
@@ -388,7 +385,12 @@ async def upload_resume(
 # ─── Health check ───
 @app.get("/api/health")
 async def health_check():
-    return {"status": "ok"}
+    providers = check_providers()
+    all_ok = all(providers.values())
+    return {
+        "status": "ok" if all_ok else "degraded",
+        "providers": providers,
+    }
 
 
 # ─── Startup: log registered routes ───


### PR DESCRIPTION
## Summary
- Added `anthropic` package and created `backend/core/llm.py` with `OpenAIClient` and `AnthropicClient` wrappers behind a unified `get_client(provider)` interface
- Refactored `server.py` to use the new wrapper — all existing flows still route through OpenAI
- Health check now reports both provider statuses (`ok` / `degraded`)

## Test plan
- [ ] Verify `/api/health` returns both provider statuses
- [ ] Verify resume upload + analysis still works via OpenAI
- [ ] Verify mock interview and career chat flows are unbroken
- [ ] Confirm `ANTHROPIC_API_KEY` in `.env` is picked up by the Anthropic client