### PR TITLE
feat: replace regex score extraction with structured outputs (#30)

### DIFF
--- a/backend/core/llm.py
+++ b/backend/core/llm.py
@@ -7,8 +7,10 @@
 
 from __future__ import annotations
 
+import json
 import os
 from dataclasses import dataclass, field
+from typing import Any
 
 from openai import OpenAI
 from anthropic import Anthropic
@@ -23,6 +25,7 @@ class LLMResponse:
     model: str
     provider: str
     usage: dict = field(default_factory=dict)
+    parsed: dict | None = None
 
 
 # ─── OpenAI client ───────────────────────────────────────
@@ -59,6 +62,46 @@ class OpenAIClient:
                 "prompt_tokens": response.usage.prompt_tokens,
                 "completion_tokens": response.usage.completion_tokens,
             },
+        )
+
+    def chat_json(
+        self,
+        messages: list[dict],
+        json_schema: dict[str, Any],
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 4000,
+    ) -> LLMResponse:
+        """Chat completion with OpenAI structured output (response_format).
+
+        `json_schema` is the value for response_format.json_schema.schema.
+        The response is guaranteed to conform to the schema.
+        """
+        response = self._client.chat.completions.create(
+            model=self.model,
+            messages=messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            response_format={
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "analysis_result",
+                    "strict": True,
+                    "schema": json_schema,
+                },
+            },
+        )
+        choice = response.choices[0]
+        parsed = json.loads(choice.message.content)
+        return LLMResponse(
+            content=choice.message.content,
+            model=response.model,
+            provider=self.provider,
+            usage={
+                "prompt_tokens": response.usage.prompt_tokens,
+                "completion_tokens": response.usage.completion_tokens,
+            },
+            parsed=parsed,
         )
 
     def ping(self) -> bool:

--- a/backend/core/prompts.py
+++ b/backend/core/prompts.py
@@ -75,32 +75,18 @@ Produce a structured summary with:
 - Top 3 specific, actionable improvement suggestions (prioritised, with concrete examples)
 - Top 3 areas to study before an interview
 
-## STRUCTURED MARKERS (MANDATORY — DO NOT SKIP)
-After your analysis, you MUST end your response with ALL of the following markers.
-The frontend parses these to display the UI. Without them, the interface breaks.
-Use the EXACT format below — one marker per line, no brackets, no extra text on the line.
+## OUTPUT FORMAT
+Your response will be returned as structured JSON with three fields: "analysis", "scores", and "highlights".
+- "analysis": Your full markdown analysis text (everything above). Write it as rich markdown.
+- "scores": An object with all 8 score integers (0-100). See scoring guidelines below.
+- "highlights": An array of exactly 4 highlight objects, each with:
+  - "icon": one of "check", "trending", "alert", "search"
+  - "title": short label (under 30 chars)
+  - "description": brief explanation (under 80 chars)
+  - Use "check"/"trending" for strengths and "alert"/"search" for areas needing work.
+  - Include 2 strengths and 2 improvement areas.
 
-### Scores
-OVERALL_FIT: 62
-HR_SCORE: 58
-ATS_SCORE: 65
-KNOWLEDGE_SCORE: 52
-KEYWORD_MATCH: 72
-FORMATTING: 90
-IMPACT_STATEMENTS: 45
-SECTION_COMPLETENESS: 80
-
-### Highlight Cards
-Emit exactly 4 highlights — 2 strengths and 2 areas for improvement.
-Format: HIGHLIGHT: icon_name | title | description
-- icon_name must be one of: check, trending, alert, search
-- "check" and "trending" are for strengths; "alert" and "search" are for areas needing work
-- Keep title under 30 characters, description under 80 characters
-
-HIGHLIGHT: check | Strong Technical Skills | Your skills section is well-organized with recognized industry keywords.
-HIGHLIGHT: trending | Clear Career Progression | Recruiters can easily see consistent growth. Each role builds on the last.
-HIGHLIGHT: alert | Missing Quantified Impact | Try: "Reduced API latency by 40%, serving 2M+ daily requests."
-HIGHLIGHT: search | Low Keyword Density | The job description mentions "distributed systems" 6 times. Your resume has it once.
+Do NOT embed score markers or HIGHLIGHT lines in the analysis text — they go in the structured fields.
 
 ## SCORING GUIDELINES
 Be honest and calibrated. Most students should score 40-75. Only exceptional matches score above 80.
@@ -145,7 +131,7 @@ Give concrete examples of how to improve, not vague advice.
 When identifying gaps, also acknowledge strengths.
 
 ## IMPORTANT
-- You MUST end your response with ALL score lines AND all 4 HIGHLIGHT lines. The UI breaks without them.
+- Populate ALL score fields and exactly 4 highlights in the structured output.
 - If the resume or job description is unclear, ask for clarification.
 - Focus on actionable insights, not generic advice.
 - Always include benchmark comparisons so the student knows where they stand relative to successful candidates.

--- a/server.py
+++ b/server.py
@@ -3,9 +3,7 @@
 # ─────────────────────────────────────────────────────────
 
 import os
-import re
 import uuid
-from datetime import datetime, timezone
 from pathlib import Path
 
 from fastapi import FastAPI, UploadFile, File, Form, Depends, HTTPException, Request, Response
@@ -75,88 +73,58 @@ class ChatResponse(BaseModel):
     highlights: list[dict] | None = None
 
 
-def extract_scores(text: str) -> dict | None:
-    """Extract all score markers from the analysis text via regex."""
-    # Primary scores
-    primary_patterns = {
-        "overall_fit": r"OVERALL_FIT:\s*(\d+)",
-        "hr_score": r"HR_SCORE:\s*(\d+)",
-        "ats_score": r"ATS_SCORE:\s*(\d+)",
-        "knowledge_score": r"KNOWLEDGE_SCORE:\s*(\d+)",
-    }
-    # Sub-scores for the breakdown bars
-    sub_patterns = {
-        "keyword_match": r"KEYWORD_MATCH:\s*(\d+)",
-        "formatting": r"FORMATTING:\s*(\d+)",
-        "impact_statements": r"IMPACT_STATEMENTS:\s*(\d+)",
-        "section_completeness": r"SECTION_COMPLETENESS:\s*(\d+)",
-    }
-    scores = {}
-    for key, pattern in {**primary_patterns, **sub_patterns}.items():
-        match = re.search(pattern, text)
-        if match:
-            scores[key] = min(100, max(0, int(match.group(1))))
+# ─── Structured output schema for analysis ──────────────
 
-    # Need at least the 4 primary scores
-    if all(k in scores for k in primary_patterns):
-        return scores
-    return None
-
-
-def extract_highlights(text: str) -> list[dict] | None:
-    """Extract the 4 highlight cards from HIGHLIGHT: markers."""
-    pattern = r"HIGHLIGHT:\s*(\w+)\s*\|\s*([^|]+?)\s*\|\s*(.+)"
-    matches = re.findall(pattern, text)
-    if len(matches) >= 4:
-        return [
-            {"icon": m[0].strip(), "title": m[1].strip(), "description": m[2].strip()}
-            for m in matches[:4]
-        ]
-    return None
-
-
-def extract_scores_via_llm(analysis_text: str) -> dict | None:
-    """Fallback: ask the LLM to extract scores from an analysis that's missing markers."""
-    try:
-        openai_client = get_client("openai")
-        resp = openai_client.chat(
-            messages=[
-                {"role": "system", "content": (
-                    "Extract numerical scores (0-100) from the resume analysis below. "
-                    "Reply with ONLY these lines, nothing else:\n"
-                    "OVERALL_FIT: <number>\nHR_SCORE: <number>\n"
-                    "ATS_SCORE: <number>\nKNOWLEDGE_SCORE: <number>\n"
-                    "KEYWORD_MATCH: <number>\nFORMATTING: <number>\n"
-                    "IMPACT_STATEMENTS: <number>\nSECTION_COMPLETENESS: <number>"
-                )},
-                {"role": "user", "content": analysis_text[:3000]},
+ANALYSIS_JSON_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "analysis": {
+            "type": "string",
+            "description": "Full markdown analysis text for display.",
+        },
+        "scores": {
+            "type": "object",
+            "properties": {
+                "overall_fit": {"type": "integer"},
+                "hr_score": {"type": "integer"},
+                "ats_score": {"type": "integer"},
+                "knowledge_score": {"type": "integer"},
+                "keyword_match": {"type": "integer"},
+                "formatting": {"type": "integer"},
+                "impact_statements": {"type": "integer"},
+                "section_completeness": {"type": "integer"},
+            },
+            "required": [
+                "overall_fit", "hr_score", "ats_score", "knowledge_score",
+                "keyword_match", "formatting", "impact_statements", "section_completeness",
             ],
-            temperature=0,
-            max_tokens=200,
-        )
-        return extract_scores(resp.content)
-    except Exception as e:
-        print(f"[SCORES] LLM fallback failed: {e}")
-        return None
+            "additionalProperties": False,
+        },
+        "highlights": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "icon": {
+                        "type": "string",
+                        "enum": ["check", "trending", "alert", "search"],
+                    },
+                    "title": {"type": "string"},
+                    "description": {"type": "string"},
+                },
+                "required": ["icon", "title", "description"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    "required": ["analysis", "scores", "highlights"],
+    "additionalProperties": False,
+}
 
 
-# All score/highlight markers that should be stripped from the displayed analysis text
-_SCORE_MARKERS = [
-    "OVERALL_FIT:", "HR_SCORE:", "ATS_SCORE:", "KNOWLEDGE_SCORE:",
-    "KEYWORD_MATCH:", "FORMATTING:", "IMPACT_STATEMENTS:", "SECTION_COMPLETENESS:",
-]
-
-
-def clean_response(text: str) -> str:
-    clean = text
-    for marker in _SCORE_MARKERS:
-        clean = re.sub(rf"{marker}\s*\d+\n?", "", clean)
-    # Remove HIGHLIGHT lines
-    clean = re.sub(r"HIGHLIGHT:\s*\w+\s*\|[^\n]*\n?", "", clean)
-    # Remove leftover markdown headers for the markers section
-    clean = re.sub(r"###\s*Scores\s*\n?", "", clean)
-    clean = re.sub(r"###\s*Highlight Cards\s*\n?", "", clean)
-    return clean.strip()
+def _clamp_scores(scores: dict) -> dict:
+    """Clamp all score values to 0-100."""
+    return {k: min(100, max(0, v)) for k, v in scores.items()}
 
 
 def detect_mode(message: str, session_data: dict) -> str:
@@ -230,31 +198,70 @@ Confident, direct, supportive. Like a sharp friend who works in recruiting.
     return ROOT_PROMPT
 
 
+def _build_messages(session_data: dict, message: str, mode: str) -> list[dict]:
+    """Build the message list for an LLM call."""
+    system_prompt = build_system_prompt(mode, session_data)
+    messages = [{"role": "system", "content": system_prompt}]
+    for h in session_data.get("history", [])[-20:]:
+        messages.append(h)
+    messages.append({"role": "user", "content": message})
+    return messages
+
+
+def run_analysis(session_data: dict, message: str) -> dict:
+    """Run resume analysis using OpenAI structured output.
+
+    Returns dict with keys: analysis (str), scores (dict), highlights (list[dict]).
+    """
+    messages = _build_messages(session_data, message, "analysis")
+    llm = get_client("openai")
+
+    try:
+        resp = llm.chat_json(
+            messages=messages,
+            json_schema=ANALYSIS_JSON_SCHEMA,
+            temperature=0.7,
+            max_tokens=4000,
+        )
+        result = resp.parsed
+
+        history = session_data.get("history", [])
+        history.append({"role": "user", "content": message})
+        history.append({"role": "assistant", "content": result["analysis"]})
+        session_data["history"] = history
+
+        return {
+            "analysis": result["analysis"],
+            "scores": _clamp_scores(result["scores"]),
+            "highlights": result["highlights"][:4],
+        }
+    except Exception as e:
+        print(f"[ANALYSIS] Structured output failed: {e}")
+        return {
+            "analysis": f"I encountered an issue processing your request. Please try again. Error: {str(e)}",
+            "scores": None,
+            "highlights": None,
+        }
+
+
 def run_completion(session_data: dict, message: str) -> str:
+    """Run a non-analysis chat completion (interview, career, root)."""
     mode = detect_mode(message, session_data)
 
     if mode in ("career", "interview"):
         session_data["mode"] = mode
 
-    system_prompt = build_system_prompt(mode, session_data)
-
-    messages = [{"role": "system", "content": system_prompt}]
-
-    history = session_data.get("history", [])
-    for h in history[-20:]:
-        messages.append(h)
-
-    messages.append({"role": "user", "content": message})
+    messages = _build_messages(session_data, message, mode)
 
     # Route to the right provider — for now everything stays on OpenAI.
-    # Phase 1 just proves the plumbing works; later tickets will flip
-    # interview + career to Anthropic.
+    # Later tickets will flip interview + career to Anthropic.
     llm = get_client("openai")
 
     try:
         resp = llm.chat(messages=messages, temperature=0.7, max_tokens=4000)
         assistant_reply = resp.content
 
+        history = session_data.get("history", [])
         history.append({"role": "user", "content": message})
         history.append({"role": "assistant", "content": assistant_reply})
         session_data["history"] = history
@@ -298,12 +305,10 @@ async def chat(req: ChatRequest, current_user: User = Depends(require_auth)):
         raise HTTPException(status_code=403, detail="Not your session.")
 
     response_text = run_completion(session_data, req.message)
-    scores = extract_scores(response_text)
 
     return ChatResponse(
-        response=clean_response(response_text),
+        response=response_text,
         session_id=req.session_id,
-        scores=scores,
     )
 
 
@@ -346,18 +351,11 @@ async def upload_resume(
     message = f"Here is my resume:\n\n{resume_content}\n\n{job_description}"
 
     session_data["mode"] = "analysis"
-    response_text = run_completion(session_data, message)
-    scores = extract_scores(response_text)
-    highlights = extract_highlights(response_text)
-
-    # Fallback: if the LLM didn't include score markers, ask it to score separately
-    if scores is None:
-        print("[SCORES] Markers not found in response — trying LLM fallback")
-        scores = extract_scores_via_llm(response_text)
+    result = run_analysis(session_data, message)
 
     session_data["has_analysis"] = True
     session_data["mode"] = None
-    session_data["analysis_summary"] = response_text[:3000]
+    session_data["analysis_summary"] = result["analysis"][:3000]
 
     try:
         store_analysis(
@@ -366,7 +364,7 @@ async def upload_resume(
             resume_text=resume_content,
             job_description=job_description,
             job_url="",
-            hr_analysis=response_text[:2000],
+            hr_analysis=result["analysis"][:2000],
             ats_analysis="",
             knowledge_gaps="",
             suggestions="",
@@ -375,10 +373,10 @@ async def upload_resume(
         print(f"DB storage warning: {e}")
 
     return ChatResponse(
-        response=clean_response(response_text),
+        response=result["analysis"],
         session_id=session_id,
-        scores=scores,
-        highlights=highlights,
+        scores=result["scores"],
+        highlights=result["highlights"],
     )
 
 


### PR DESCRIPTION
## Summary
- Remove `extract_scores()`, `extract_highlights()`, `extract_scores_via_llm()`, and `clean_response()` — all regex-based score parsing eliminated
- Add `chat_json()` method to `OpenAIClient` using OpenAI's `response_format` with strict JSON schema validation
- Analysis endpoint now returns scores and highlights as guaranteed structured data — no more regex fallbacks or marker stripping
- Update `RESUME_ANALYST_PROMPT` to instruct the LLM about structured JSON output instead of embedding markers in markdown

## Test plan
- [x] Upload a resume + job description → verify scores display correctly in all 8 fields
- [x] Verify highlight cards render (4 cards: 2 strengths, 2 improvements)
- [x] Verify analysis markdown renders cleanly without leftover markers
- [x] Test with 3+ different resumes to confirm consistent structured output
- [x] Verify chat/interview/career modes still work (no regression from refactor)

Closes #30