### PR TITLE
fix: analysis truncation and duplicate fallback display

### DIFF
--- a/frontend/app/(dashboard)/analysis-center/page.tsx
+++ b/frontend/app/(dashboard)/analysis-center/page.tsx
@@ -513,8 +513,8 @@ export default function AnalysisCenterPage() {
             </motion.div>
           )}
 
-          {/* Fallback: if sections didn't parse, show full analysis */}
-          {analysisText && !sections['overall assessment'] && !sections['hr analysis'] && (
+          {/* Fallback: only if NO recognized sections parsed at all */}
+          {analysisText && Object.keys(sections).length === 0 && (
             <motion.div variants={fadeUp} className="glass-card rounded-xl p-4">
               <h3 className="font-sans text-[10px] font-semibold text-muted-foreground uppercase tracking-wider mb-3">Detailed Analysis</h3>
               <div className="font-sans text-xs"><Markdown>{analysisText}</Markdown></div>

--- a/server.py
+++ b/server.py
@@ -217,11 +217,14 @@ def run_analysis(session_data: dict, message: str) -> dict:
     llm = get_client("openai")
 
     try:
+        # Analysis needs higher token limit: the full markdown (Resume Breakdown,
+        # HR Analysis, ATS, Knowledge Gaps, Overall Assessment) is wrapped inside
+        # a JSON object alongside scores and highlights. 4000 truncates.
         resp = llm.chat_json(
             messages=messages,
             json_schema=ANALYSIS_JSON_SCHEMA,
             temperature=0.7,
-            max_tokens=4000,
+            max_tokens=10000,
         )
         result = resp.parsed
 


### PR DESCRIPTION
Increase max_tokens from 4000 to 10000 for structured output — the full analysis markdown (5 sections) wrapped in JSON was being cut off, so only Resume Breakdown survived. Also tighten the fallback condition to only render when zero sections parsed, preventing duplicate content.